### PR TITLE
Add attestation JSON and S3 upload receipt

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -155,8 +155,10 @@ jobs:
           path: |
             ci-output/ci-artifacts.zip
             ci-output/attestation.pdf
+            ci-output/attestation.json
             ci-output/timestamp.tsr
             ci-output/tsa-certchain.pem
+            ci-output/s3-receipt.json
           retention-days: 90
 
       - name: Cleanup keypair

--- a/scripts/attest.mjs
+++ b/scripts/attest.mjs
@@ -453,6 +453,29 @@ async function main() {
         region,
       );
       step("Uploaded to S3", `s3://${bucket}/${s3Prefix}/`);
+
+      // Write S3 receipt so downstream jobs can verify the upload occurred
+      const uploadedFiles = [
+        ...includedFiles,
+        ZIP_FILENAME,
+        PDF_FILENAME,
+        ...(existsSync(tsrPath) ? [TSR_FILENAME] : []),
+        ...(existsSync(chainPath) ? [TSA_CHAIN_FILENAME] : []),
+      ];
+      writeFileSync(
+        `${outputDir}/s3-receipt.json`,
+        JSON.stringify(
+          {
+            bucket,
+            prefix: s3Prefix,
+            region,
+            uploaded_files: uploadedFiles,
+            uploaded_at: new Date().toISOString(),
+          },
+          null,
+          2,
+        ),
+      );
     } catch (err) {
       console.warn(`  S3 upload failed (non-fatal): ${err.message}`);
       step("S3 upload", `FAILED - ${err.message}`);
@@ -463,6 +486,12 @@ async function main() {
 
   console.log("\nAttestation complete.");
   console.log(JSON.stringify(evidence, null, 2));
+
+  // Write machine-readable attestation JSON alongside the PDF
+  writeFileSync(
+    `${outputDir}/attestation.json`,
+    JSON.stringify(evidence, null, 2),
+  );
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Write attestation.json (machine-readable companion) alongside the PDF in attest.mjs
- Write s3-receipt.json after successful S3 upload with bucket, prefix, region, file list
- Add both to ci-cd.yml upload-artifact paths

## Test plan
- [ ] CI passes — attest job produces attestation.json in output
- [ ] S3 receipt written when S3_COMPLIANCE_BUCKET is set
- [ ] No receipt when S3 upload is skipped (graceful absence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (Claude Code) <noreply@anthropic.com>