### PR TITLE
Include test and coverage in evidence bundle

### DIFF
--- a/.github/workflows/golden-pipeline.yml
+++ b/.github/workflows/golden-pipeline.yml
@@ -419,7 +419,7 @@ jobs:
   verify-evidence:
     name: Verify Evidence
     runs-on: ubuntu-latest
-    needs: [vulnerability-scan, sbom, oscal]
+    needs: [secrets-scan, test, e2e, vulnerability-scan, sbom, oscal]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/scripts/verify-evidence.js
+++ b/scripts/verify-evidence.js
@@ -26,6 +26,12 @@ const expected = [
   { artifact: "oscal", file: "ssp-fragment.json" },
 ];
 
+const expectedDirs = [
+  { artifact: "surefire-reports", dir: "surefire-reports" },
+  { artifact: "jacoco-report", dir: "jacoco-report" },
+  { artifact: "frontend-coverage", dir: "frontend-coverage" },
+];
+
 function walk(dir) {
   const out = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -57,6 +63,20 @@ const entries = files.map((f) => ({
 const byName = new Set(entries.map((e) => path.basename(e.path)));
 const missing = expected.filter((x) => !byName.has(x.file));
 
+// Directory-based checks: each expectedDir must exist as a subdirectory
+// under the evidence root and contain at least one file.
+const missingDirs = expectedDirs.filter((x) => {
+  const dirPath = path.join(evidenceDir, x.dir);
+  if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
+    return true;
+  }
+  // Must contain at least one file
+  const dirFiles = walk(dirPath);
+  return dirFiles.length === 0;
+});
+
+const totalMissing = missing.length + missingDirs.length;
+
 const manifest = {
   generated_at: new Date().toISOString(),
   commit: process.env.COMMIT_SHA || process.env.GITHUB_SHA || "unknown",
@@ -65,6 +85,8 @@ const manifest = {
   artifacts: entries,
   expected,
   missing,
+  expectedDirs,
+  missingDirs,
 };
 
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
@@ -72,18 +94,28 @@ fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
 console.log(
   JSON.stringify({
     event: "verify_evidence",
-    severity: missing.length ? "high" : "info",
+    severity: totalMissing ? "high" : "info",
     artifacts_found: entries.length,
     missing_count: missing.length,
     missing_files: missing.map((m) => m.file),
+    missing_dir_count: missingDirs.length,
+    missing_dirs: missingDirs.map((m) => m.dir),
     timestamp: manifest.generated_at,
   }),
 );
 
-if (missing.length > 0) {
-  console.error(
-    `evidence manifest incomplete — missing ${missing.length} expected artifact(s): ` +
-      missing.map((m) => m.file).join(", "),
-  );
+if (totalMissing > 0) {
+  const parts = [];
+  if (missing.length > 0) {
+    parts.push(
+      `${missing.length} expected file(s): ${missing.map((m) => m.file).join(", ")}`,
+    );
+  }
+  if (missingDirs.length > 0) {
+    parts.push(
+      `${missingDirs.length} expected dir(s): ${missingDirs.map((m) => m.dir).join(", ")}`,
+    );
+  }
+  console.error(`evidence manifest incomplete — missing ${parts.join("; ")}`);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Add test, e2e, secrets-scan to verify-evidence job dependencies
- Add directory-based expectations (surefire-reports, jacoco-report, frontend-coverage) to verify-evidence.js
- Test/coverage artifacts now appear in the evidence manifest

## Test plan
- [ ] CI passes — verify-evidence job waits for test and e2e
- [ ] Evidence manifest includes surefire, jacoco, frontend-coverage entries
- [ ] Missing directory triggers drift detection failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (Claude Code) <noreply@anthropic.com>