### PR TITLE
Wire gitleaks findings into OSCAL assessment

### DIFF
--- a/.github/workflows/golden-pipeline.yml
+++ b/.github/workflows/golden-pipeline.yml
@@ -430,7 +430,7 @@ jobs:
   oscal:
     name: OSCAL (M-24-15)
     runs-on: ubuntu-latest
-    needs: vulnerability-scan
+    needs: [secrets-scan, vulnerability-scan]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -442,7 +442,7 @@ jobs:
       - name: Download vulnerability scan evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: "{npm-audit,trivy-results}"
+          pattern: "{gitleaks-report,npm-audit,trivy-results}"
           merge-multiple: true
           path: evidence/
 

--- a/scripts/generate-oscal.js
+++ b/scripts/generate-oscal.js
@@ -57,11 +57,55 @@ function readJsonIfExists(p) {
 
 const npmAudit = readJsonIfExists(path.join(evidenceDir, "npm-audit.json"));
 const trivy = readJsonIfExists(path.join(evidenceDir, "trivy-results.json"));
+const gitleaks = readJsonIfExists(path.join(evidenceDir, "gitleaks-report.json"));
 
 // --- Build observations and findings from scan results ---
 
 const observations = [];
 const findings = [];
+
+// --- Gitleaks (SI-3: secrets scan) ---
+
+if (gitleaks) {
+  const gitleaksFindings = gitleaks.findings || gitleaks;
+  const items = Array.isArray(gitleaksFindings) ? gitleaksFindings : [];
+
+  if (items.length > 0) {
+    for (const leak of items) {
+      const obsUuid = uuid();
+      const desc = `${leak.RuleID || "secret"}: ${leak.File || "unknown file"}` +
+        (leak.StartLine ? ` line ${leak.StartLine}` : "");
+
+      observations.push({
+        uuid: obsUuid,
+        title: `gitleaks: ${leak.RuleID || "secret detected"}`,
+        description: leak.Description || desc,
+        methods: ["TEST"],
+        types: ["finding"],
+        subjects: [{ "subject-uuid": componentUuid, type: "component" }],
+        collected: now,
+        "relevant-evidence": [
+          {
+            href: "#gitleaks-evidence",
+            description: desc,
+          },
+        ],
+      });
+
+      findings.push({
+        uuid: uuid(),
+        title: `gitleaks: ${leak.RuleID || "secret detected"}`,
+        description: leak.Description || desc,
+        target: {
+          type: "objective-id",
+          "target-id": "si-3_obj",
+          status: { state: "not-satisfied" },
+        },
+        "related-observations": [{ "observation-uuid": obsUuid }],
+      });
+    }
+  }
+}
 
 if (npmAudit && npmAudit.vulnerabilities) {
   for (const [name, v] of Object.entries(npmAudit.vulnerabilities)) {


### PR DESCRIPTION
## Summary
- generate-oscal.js now reads gitleaks-report.json and maps findings to SI-3 observations
- OSCAL job downloads gitleaks-report artifact and depends on secrets-scan
- Skill updated in dave-skills to require gitleaks as an OSCAL input

## Test plan
- [ ] CI passes with no gitleaks findings (clean path)
- [ ] OSCAL assessment-results.json still validates against schema
- [ ] If gitleaks were to find a secret, it would appear as an SI-3 observation

🤖 Generated with [Claude Code](https://claude.com/claude-code)