### PR TITLE
Add containerized full-stack e2e tests

### DIFF
--- a/docker/e2e/Dockerfile.app
+++ b/docker/e2e/Dockerfile.app
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17-jre
+RUN apt-get update -qq && apt-get install -y -qq postgresql-client curl > /dev/null 2>&1
+WORKDIR /app
+COPY target/todo-app-*.jar app.jar
+COPY docker/postgres/init/02_seed.sql /seed.sql
+COPY docker/e2e/start-app.sh /start-app.sh
+RUN chmod +x /start-app.sh
+EXPOSE 8081
+CMD ["/start-app.sh"]

--- a/docker/e2e/Dockerfile.playwright
+++ b/docker/e2e/Dockerfile.playwright
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/playwright:v1.58.2-jammy
+RUN apt-get update -qq && apt-get install -y -qq dnsutils > /dev/null 2>&1 || true
+WORKDIR /app
+COPY src/main/frontend/package.json src/main/frontend/package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY src/main/frontend/tests/ ./tests/
+COPY src/main/frontend/playwright.integration.config.ts ./
+RUN npx playwright install --with-deps chromium webkit
+COPY docker/e2e/run-tests.sh /run-tests.sh
+RUN chmod +x /run-tests.sh
+CMD ["/run-tests.sh"]

--- a/docker/e2e/compose.yaml
+++ b/docker/e2e/compose.yaml
@@ -1,0 +1,57 @@
+# Full-stack e2e: Postgres + Spring Boot JAR + Playwright.
+#
+# Usage:
+#   ./mvnw -B -DskipTests package
+#   docker compose -f docker/e2e/compose.yaml up --build --exit-code-from playwright
+#
+# The app container starts Spring Boot, waits for readiness, seeds
+# the database, then stays running. Playwright hits the real app
+# on port 8081 — no proxy, no dev server, same as production.
+
+services:
+  postgres:
+    build:
+      context: ../postgres
+    container_name: e2e-postgres
+    environment:
+      POSTGRES_DB: todoapp
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d todoapp"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+
+  app:
+    build:
+      context: ../..
+      dockerfile: docker/e2e/Dockerfile.app
+    container_name: e2e-app
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/todoapp
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      SERVER_PORT: "8081"
+      PGHOST: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8081/login > /dev/null || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+
+  playwright:
+    build:
+      context: ../..
+      dockerfile: docker/e2e/Dockerfile.playwright
+    container_name: e2e-playwright
+    depends_on:
+      app:
+        condition: service_healthy
+    environment:
+      CI: "true"

--- a/docker/e2e/run-tests.sh
+++ b/docker/e2e/run-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Resolve the app hostname to an IP so Playwright's sandboxed
+# browsers (which use a separate network namespace) can reach it.
+
+APP_IP=$(dig +short app 2>/dev/null | head -1)
+if [ -z "$APP_IP" ]; then
+  APP_IP=$(python3 -c "import socket; print(socket.gethostbyname('app'))" 2>/dev/null)
+fi
+
+if [ -z "$APP_IP" ]; then
+  echo "ERROR: could not resolve 'app' hostname"
+  exit 1
+fi
+
+echo "Resolved app -> $APP_IP"
+export PLAYWRIGHT_BASE_URL="http://${APP_IP}:8081"
+exec npx playwright test --config=playwright.integration.config.ts

--- a/docker/e2e/start-app.sh
+++ b/docker/e2e/start-app.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Start Spring Boot in the background, wait for it to be ready,
+# seed the database, then keep the app in the foreground.
+
+java -jar app.jar &
+APP_PID=$!
+
+echo "Waiting for Spring Boot to start..."
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:8081/login > /dev/null 2>&1; then
+    echo "Spring Boot is ready."
+    break
+  fi
+  sleep 1
+done
+
+echo "Seeding database..."
+PGHOST=${PGHOST:-postgres} PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres PGDATABASE=todoapp \
+  psql -f /seed.sql
+
+echo "Seed complete. App running on PID $APP_PID."
+wait $APP_PID

--- a/src/main/frontend/playwright.integration.config.ts
+++ b/src/main/frontend/playwright.integration.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Integration config: hits the real Spring Boot backend (no mocks).
+// Used by docker/e2e/compose.yaml.
+
+export default defineConfig({
+  testDir: './tests/integration',
+  timeout: 30_000,
+  reporter: [
+    ['html', { outputFolder: 'coverage/playwright/html-report', open: 'never' }],
+    ['list']
+  ],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8081',
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 14 Pro'] }
+    }
+  ]
+});

--- a/src/main/frontend/tests/integration/kanban.integration.spec.ts
+++ b/src/main/frontend/tests/integration/kanban.integration.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+// Full-stack integration test: no mocked routes.
+// Runs against a real Spring Boot + PostgreSQL backend with
+// seed data (synth_alice / password123).
+
+test.describe('Kanban board (full stack)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Username').fill('synth_alice');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page.getByRole('heading', { name: 'Kanban Board' })).toBeVisible();
+  });
+
+  test('displays seed data after login', async ({ page }) => {
+    // synth_alice has a TODO card: "Set up project board"
+    await expect(page.getByText('Set up project board')).toBeVisible();
+  });
+
+  test('create, move, and delete a card', async ({ page }) => {
+    // Create
+    await page.getByPlaceholder('New task title').fill('Integration test card');
+    await page.getByPlaceholder('Description (optional)').fill('Created by Playwright integration');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.getByText('Integration test card')).toBeVisible();
+
+    // Move to Done
+    const card = page.locator('.kanban-card', { hasText: 'Integration test card' }).first();
+    await card.locator('select').selectOption('DONE');
+    await expect(
+      page.locator('section', { hasText: 'Done' }).getByText('Integration test card')
+    ).toBeVisible();
+
+    // Delete
+    await card.getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByText('Integration test card')).toHaveCount(0);
+  });
+
+  test('card persists across page reload', async ({ page }) => {
+    // Create a card
+    await page.getByPlaceholder('New task title').fill('Persistence check');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.getByText('Persistence check')).toBeVisible();
+
+    // Reload and verify it survived
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Kanban Board' })).toBeVisible();
+    await expect(page.getByText('Persistence check')).toBeVisible();
+
+    // Cleanup
+    const card = page.locator('.kanban-card', { hasText: 'Persistence check' }).first();
+    await card.getByRole('button', { name: 'Delete' }).click();
+  });
+});


### PR DESCRIPTION
## Summary
- Docker Compose setup: Postgres + Spring Boot JAR + Playwright
- Integration tests hit the real backend with seed data (synth_alice)
- Three tests: seed data display, card CRUD, persistence across reload
- Runs on Chromium + mobile-safari (iPhone 14 Pro)
- No host volume mounts — everything built into images

## Usage
```
./mvnw -B -DskipTests package
docker compose -f docker/e2e/compose.yaml up --build --exit-code-from playwright
```

## Test plan
- [x] All 6 test cases pass locally (3 tests x 2 browsers)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)