### PR TITLE
Add Checkstyle linting to Java backend

### DIFF
--- a/.github/workflows/golden-pipeline.yml
+++ b/.github/workflows/golden-pipeline.yml
@@ -370,6 +370,37 @@ jobs:
           path: audit-event-vulnerability-scan.json
           retention-days: ${{ inputs.evidence-retention-days }}
 
+  checkstyle:
+    name: Checkstyle (Java lint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Java ${{ inputs.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: ${{ inputs.java-distribution }}
+          cache: maven
+
+      - name: Run Checkstyle
+        run: ./mvnw -B -ntp checkstyle:check
+
+      - name: Emit audit event
+        if: always()
+        run: |
+          event='{"event":"checkstyle","severity":"info","status":"'"${{ job.status }}"'","run_id":"'"${{ github.run_id }}"'","commit":"'"${{ github.sha }}"'","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
+          echo "$event"
+          echo "$event" > audit-event-checkstyle.json
+
+      - name: Upload audit event
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: audit-event-checkstyle
+          path: audit-event-checkstyle.json
+          retention-days: ${{ inputs.evidence-retention-days }}
+
   sbom:
     name: SBOM (PW.4)
     runs-on: ubuntu-latest
@@ -479,7 +510,7 @@ jobs:
   verify-evidence:
     name: Verify Evidence
     runs-on: ubuntu-latest
-    needs: [secrets-scan, test, e2e, vulnerability-scan, sbom, oscal]
+    needs: [secrets-scan, test, e2e, vulnerability-scan, checkstyle, sbom, oscal]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+  Checkstyle configuration based on Google Java Style, with relaxations
+  for the current codebase. Rules will be tightened incrementally.
+-->
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <property name="fileExtensions" value="java"/>
+
+  <!-- Suppress warnings for generated or vendored code -->
+  <module name="SuppressWarningsFilter"/>
+
+  <!-- File-level checks -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+    <property name="severity" value="ignore"/>
+  </module>
+
+  <module name="TreeWalker">
+    <module name="SuppressWarningsHolder"/>
+
+    <!-- ===== IMPORTS ===== -->
+    <module name="UnusedImports"/>
+    <module name="RedundantImport"/>
+    <!-- CustomImportOrder disabled: imports not ordered by Google convention -->
+
+    <!-- ===== WHITESPACE ===== -->
+    <module name="NoLineWrap">
+      <property name="tokens" value="IMPORT,STATIC_IMPORT,PACKAGE_DEF"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="tokens"
+        value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,
+               BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,DO_WHILE,EQUAL,GE,GT,LAMBDA,
+               LAND,LCURLY,LE,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,
+               LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,
+               LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,
+               LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,
+               PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,
+               STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+        value="COMMA,SEMI,TYPECAST,LITERAL_IF,LITERAL_ELSE,LITERAL_WHILE,
+               LITERAL_DO,LITERAL_FOR,DO_WHILE"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+        value="COMMA,SEMI,POST_INC,POST_DEC,DOT,LABELED_STAT,METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="GenericWhitespace"/>
+
+    <!-- ===== BLOCKS ===== -->
+    <!-- NeedBraces disabled: codebase has single-line if/return patterns in equals() -->
+    <!-- LeftCurly disabled: codebase uses inline single-line getters/setters -->
+    <module name="EmptyBlock">
+      <property name="option" value="TEXT"/>
+      <property name="tokens"
+        value="LITERAL_WHILE,LITERAL_TRY,LITERAL_CATCH,LITERAL_FINALLY,
+               LITERAL_DO,LITERAL_IF,LITERAL_ELSE,LITERAL_FOR,INSTANCE_INIT,
+               STATIC_INIT,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_CASE,
+               LITERAL_DEFAULT,ARRAY_INIT"/>
+    </module>
+    <module name="RightCurly">
+      <property name="tokens"
+        value="LITERAL_TRY,LITERAL_CATCH,LITERAL_FINALLY,LITERAL_IF,
+               LITERAL_ELSE,LITERAL_DO"/>
+    </module>
+
+    <!-- ===== CODING ===== -->
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected|ignore"/>
+    </module>
+
+    <!-- ===== NAMING ===== -->
+    <!-- AbbreviationAsWordInName disabled: codebase uses JwtUtil, etc. -->
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+    </module>
+    <module name="TypeName"/>
+    <module name="ConstantName"/>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+    </module>
+    <!-- MemberName disabled: may conflict with Spring field naming conventions -->
+    <!-- LocalVariableName covered above with relaxed pattern -->
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+    </module>
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
+    </module>
+
+    <!-- ===== JAVADOC ===== -->
+    <!-- All Javadoc checks disabled: no Javadoc in current codebase -->
+
+    <!-- ===== ANNOTATIONS ===== -->
+    <module name="AnnotationLocation">
+      <property name="tokens"
+        value="CLASS_DEF,INTERFACE_DEF,ENUM_DEF,METHOD_DEF,CTOR_DEF"/>
+    </module>
+  </module>
+
+  <!-- File-level length check (must live under Checker, not TreeWalker) -->
+  <module name="LineLength">
+    <property name="max" value="150"/>
+    <property name="ignorePattern"
+      value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <violationSeverity>warning</violationSeverity>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>checkstyle-validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>10.21.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project> 


### PR DESCRIPTION
## Summary
- Add maven-checkstyle-plugin (10.21.4) bound to validate phase
- Google checks base with relaxations for current codebase (no javadoc, 150 char lines, etc.)
- Add checkstyle job to golden pipeline
- 0 violations on current code

## Test plan
- [x] `./mvnw -B -ntp checkstyle:check` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)