### PR TITLE
Migrate jjwt 0.11.5 -> 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <jwt.version>0.11.5</jwt.version>
+        <jwt.version>0.13.0</jwt.version>
         <testcontainers.version>1.21.4</testcontainers.version>
 
         <!-- CVE remediation: override Spring Boot 2.7.18 BOM-pinned

--- a/src/main/java/com/todoapp/util/JwtUtil.java
+++ b/src/main/java/com/todoapp/util/JwtUtil.java
@@ -2,7 +2,6 @@ package com.todoapp.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -42,11 +41,11 @@ public class JwtUtil {
     }
 
     private Claims extractAllClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
                 .build()
-                .parseClaimsJws(token)
-                .getBody();
+                .parseSignedClaims(token)
+                .getPayload();
     }
 
     private Boolean isTokenExpired(String token) {
@@ -60,11 +59,11 @@ public class JwtUtil {
 
     private String createToken(Map<String, Object> claims, String subject) {
         return Jwts.builder()
-                .setClaims(claims)
-                .setSubject(subject)
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + expiration))
-                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .claims(claims)
+                .subject(subject)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSigningKey(), Jwts.SIG.HS256)
                 .compact();
     }
 
@@ -72,4 +71,4 @@ public class JwtUtil {
         final String username = extractUsername(token);
         return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
     }
-} 
+}


### PR DESCRIPTION
## Summary

Last item from the dep-refresh deferred-major backlog. jjwt 0.12 introduced a new fluent API and dropped the `parserBuilder`/`setX` methods that this code was using; 0.13.0 keeps the same modern surface.

## Diff: `JwtUtil.java`

| Old (0.11.x) | New (0.13.0) |
| --- | --- |
| `Jwts.parserBuilder()` | `Jwts.parser()` |
| `.setSigningKey(key)` | `.verifyWith(key)` |
| `.parseClaimsJws(t).getBody()` | `.parseSignedClaims(t).getPayload()` |
| `.setClaims(claims)` | `.claims(claims)` |
| `.setSubject(s)` | `.subject(s)` |
| `.setIssuedAt(d)` | `.issuedAt(d)` |
| `.setExpiration(d)` | `.expiration(d)` |
| `signWith(key, SignatureAlgorithm.HS256)` | `signWith(key, Jwts.SIG.HS256)` |

`SignatureAlgorithm` import dropped; algorithms now live under the fluent `Jwts.SIG` namespace.

## Tests

`JwtUtilTest.java` is **unchanged** — it imports `ExpiredJwtException` which is stable across the migration. All 5 test cases pass on the new API:

- `generateAndExtractUsername`
- `extractExpiration`
- `validateTokenValid`
- `validateTokenWrongUser`
- `validateTokenExpired` (the expired-token round-trip → `ExpiredJwtException`)

## Verification

Local: `SPRING_PROFILES_ACTIVE=test ./mvnw -B -ntp verify` → BUILD SUCCESS, all backend tests pass, JaCoCo coverage gate met.

## Test plan

- [ ] Golden Pipeline green end-to-end on this PR
- [ ] `Test (backend + frontend)` job passes — JWT signing + parsing exercised by `JwtUtilTest` + `AuthServiceTest`
- [ ] No new Trivy findings (jjwt's dependency tree is small and stable)
- [ ] Manual smoke after merge: existing JWTs minted by 0.11.x are still parseable by 0.13.x — same algorithm (HS256) and key derivation, so they should round-trip cleanly. New tokens are minted with the same external shape.

https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp

---
_Generated by [Claude Code](https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp)_