### PR TITLE
Add PR-summary comment bot (phone-friendly pipeline overview)

### DIFF
--- a/.github/workflows/golden-pipeline.yml
+++ b/.github/workflows/golden-pipeline.yml
@@ -576,3 +576,46 @@ jobs:
           name: audit-event-verify-evidence
           path: audit-event-verify-evidence.json
           retention-days: ${{ inputs.evidence-retention-days }}
+
+  pr-summary:
+    name: PR Summary
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'pull_request'
+    needs:
+      - secrets-scan
+      - test
+      - e2e
+      - vulnerability-scan
+      - sbom
+      - oscal
+      - verify-evidence
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Node ${{ inputs.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Download all evidence artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: evidence/
+
+      - name: Generate PR summary markdown
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/pr-summary.mjs evidence/ > pr-summary.md
+
+      - name: Append summary to step output
+        run: cat pr-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: pr-summary
+          path: pr-summary.md

--- a/scripts/pr-summary.mjs
+++ b/scripts/pr-summary.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+// Generates a PR-summary markdown comment from the pipeline's evidence
+// artifacts. Reads from a directory tree like:
+//
+//   evidence/
+//     surefire-reports/TEST-*.xml + *.txt
+//     jacoco-report/jacoco.xml
+//     frontend-coverage/coverage-summary.json
+//     npm-audit/npm-audit.json   (or flat)
+//     trivy-results/trivy-results.json
+//     gitleaks-report/gitleaks-report.json
+//     sbom/sbom.cyclonedx.json
+//     oscal/{assessment-results,component-definition,ssp-fragment}.json
+//     evidence-manifest/evidence-manifest.json
+//     playwright-test-results/   (subdirs per failed test)
+//
+// Emits the comment body to stdout. Each section is best-effort —
+// missing artifacts are reported as "—" rather than aborting.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const [, , evidenceDirArg] = process.argv;
+const evidenceDir = path.resolve(evidenceDirArg || "evidence");
+const runUrl = process.env.RUN_URL || "";
+const headSha = process.env.HEAD_SHA || "";
+
+function findFile(name) {
+  const candidates = [
+    path.join(evidenceDir, name),
+    ...fs.existsSync(evidenceDir)
+      ? fs
+          .readdirSync(evidenceDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((d) => path.join(evidenceDir, d.name, name))
+      : [],
+  ];
+  return candidates.find((p) => fs.existsSync(p));
+}
+
+function findDir(name) {
+  const candidates = [
+    path.join(evidenceDir, name),
+    ...fs.existsSync(evidenceDir)
+      ? fs
+          .readdirSync(evidenceDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory() && e.name === name)
+          .map((d) => path.join(evidenceDir, d.name))
+      : [],
+  ];
+  return candidates.find((p) => fs.existsSync(p));
+}
+
+function readJson(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readText(p) {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// --- Surefire (backend tests) -------------------------------------------------
+
+function summarizeSurefire() {
+  const dir = findDir("surefire-reports");
+  if (!dir) return null;
+  let total = 0;
+  let failures = 0;
+  let errors = 0;
+  let skipped = 0;
+  for (const entry of fs.readdirSync(dir)) {
+    if (!entry.endsWith(".txt")) continue;
+    const txt = readText(path.join(dir, entry));
+    if (!txt) continue;
+    const m = txt.match(
+      /Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+),\s*Skipped:\s*(\d+)/,
+    );
+    if (m) {
+      total += +m[1];
+      failures += +m[2];
+      errors += +m[3];
+      skipped += +m[4];
+    }
+  }
+  return { total, failures, errors, skipped };
+}
+
+// --- JaCoCo (backend coverage) ------------------------------------------------
+
+function summarizeJacoco() {
+  const xmlPath = findFile("jacoco.xml") ||
+    (() => {
+      const dir = findDir("jacoco-report");
+      return dir ? path.join(dir, "jacoco.xml") : null;
+    })();
+  if (!xmlPath || !fs.existsSync(xmlPath)) return null;
+  const xml = readText(xmlPath);
+  if (!xml) return null;
+  // Bundle-level counters appear last in the JaCoCo XML report; the final
+  // <counter type="LINE" .../> and <counter type="BRANCH" .../> in the doc
+  // are the bundle totals.
+  const counters = {};
+  for (const m of xml.matchAll(
+    /<counter\s+type="(\w+)"\s+missed="(\d+)"\s+covered="(\d+)"/g,
+  )) {
+    counters[m[1]] = { missed: +m[2], covered: +m[3] };
+  }
+  function pct(c) {
+    if (!c) return null;
+    const total = c.missed + c.covered;
+    return total === 0 ? null : (c.covered / total) * 100;
+  }
+  return {
+    line: pct(counters.LINE),
+    branch: pct(counters.BRANCH),
+  };
+}
+
+// --- Frontend coverage --------------------------------------------------------
+
+function summarizeFrontendCoverage() {
+  const candidates = [
+    "frontend-coverage/coverage-summary.json",
+    "frontend-coverage/coverage-final.json",
+  ];
+  for (const c of candidates) {
+    const p = path.join(evidenceDir, c);
+    if (fs.existsSync(p)) {
+      const data = readJson(p);
+      if (data && data.total) {
+        return {
+          line: data.total.lines && data.total.lines.pct,
+          branch: data.total.branches && data.total.branches.pct,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+// --- Trivy --------------------------------------------------------------------
+
+function summarizeTrivy() {
+  const p = findFile("trivy-results.json");
+  if (!p) return null;
+  const data = readJson(p);
+  if (!data) return null;
+  const findings = (data.Results || []).flatMap(
+    (r) => r.Vulnerabilities || [],
+  );
+  const bySev = {};
+  for (const v of findings) {
+    const s = (v.Severity || "UNKNOWN").toUpperCase();
+    bySev[s] = (bySev[s] || 0) + 1;
+  }
+  return { total: findings.length, bySev };
+}
+
+// --- npm audit ----------------------------------------------------------------
+
+function summarizeNpmAudit() {
+  const p = findFile("npm-audit.json");
+  if (!p) return null;
+  const data = readJson(p);
+  if (!data) return null;
+  const vulns = data.vulnerabilities || {};
+  const counts = data.metadata && data.metadata.vulnerabilities;
+  if (counts) return counts;
+  // Fallback: count direct entries
+  const bySev = {};
+  for (const v of Object.values(vulns)) {
+    const s = (v.severity || "info").toLowerCase();
+    bySev[s] = (bySev[s] || 0) + 1;
+  }
+  return bySev;
+}
+
+// --- Gitleaks -----------------------------------------------------------------
+
+function summarizeGitleaks() {
+  const p = findFile("gitleaks-report.json");
+  if (!p) return null;
+  const data = readJson(p);
+  if (!data) return null;
+  const findings = data.findings || (Array.isArray(data) ? data : []);
+  return { total: Array.isArray(findings) ? findings.length : 0 };
+}
+
+// --- Evidence manifest --------------------------------------------------------
+
+function summarizeManifest() {
+  const p = findFile("evidence-manifest.json");
+  if (!p) return null;
+  const data = readJson(p);
+  if (!data) return null;
+  return {
+    artifacts: (data.artifacts || []).length,
+    missing: (data.missing || []).length + (data.missingDirs || []).length,
+  };
+}
+
+// --- Playwright ---------------------------------------------------------------
+
+function summarizePlaywright() {
+  const dir = findDir("playwright-test-results");
+  if (!dir) return null;
+  const entries = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory());
+  return { failedSpecs: entries.length };
+}
+
+// --- Compose markdown ---------------------------------------------------------
+
+const surefire = summarizeSurefire();
+const jacoco = summarizeJacoco();
+const feCov = summarizeFrontendCoverage();
+const trivy = summarizeTrivy();
+const npmAudit = summarizeNpmAudit();
+const gitleaks = summarizeGitleaks();
+const manifest = summarizeManifest();
+const playwright = summarizePlaywright();
+
+const sections = [];
+
+const greenCheck = "✅";
+const redX = "❌";
+const dash = "—";
+
+function pct(v) {
+  return v == null ? dash : `${v.toFixed(1)}%`;
+}
+
+function trivyOk(t) {
+  return t == null || t.total === 0;
+}
+function npmOk(a) {
+  if (!a) return true;
+  return (a.high || 0) + (a.critical || 0) === 0;
+}
+function gitleaksOk(g) {
+  return !g || g.total === 0;
+}
+function manifestOk(m) {
+  return !m || m.missing === 0;
+}
+function testsOk(s) {
+  return !s || (s.failures === 0 && s.errors === 0);
+}
+function playwrightOk(p) {
+  return !p || p.failedSpecs === 0;
+}
+
+const allOk =
+  testsOk(surefire) &&
+  trivyOk(trivy) &&
+  npmOk(npmAudit) &&
+  gitleaksOk(gitleaks) &&
+  manifestOk(manifest) &&
+  playwrightOk(playwright);
+
+sections.push("<!-- claude-pr-summary -->");
+sections.push("## Pipeline summary");
+sections.push("");
+sections.push(
+  `**Status:** ${allOk ? greenCheck + " all signals green" : redX + " attention needed"}` +
+    (headSha ? ` · \`${headSha.slice(0, 7)}\`` : ""),
+);
+sections.push("");
+
+const rows = [];
+if (surefire) {
+  const ok = testsOk(surefire);
+  rows.push([
+    "Backend tests (Surefire)",
+    `${ok ? greenCheck : redX} ${surefire.total} run, ${surefire.failures} failed, ${surefire.errors} errored, ${surefire.skipped} skipped`,
+  ]);
+}
+if (jacoco) {
+  rows.push(["JaCoCo line coverage", pct(jacoco.line)]);
+  rows.push(["JaCoCo branch coverage", pct(jacoco.branch)]);
+}
+if (feCov) {
+  rows.push(["Frontend line coverage", pct(feCov.line)]);
+  rows.push(["Frontend branch coverage", pct(feCov.branch)]);
+}
+if (playwright) {
+  const ok = playwrightOk(playwright);
+  rows.push([
+    "E2E (Playwright, desktop + mobile)",
+    `${ok ? greenCheck : redX} ${playwright.failedSpecs} failed spec(s)`,
+  ]);
+}
+if (trivy) {
+  const ok = trivyOk(trivy);
+  const bySev = Object.entries(trivy.bySev || {})
+    .map(([s, n]) => `${s}: ${n}`)
+    .join(", ") || "none";
+  rows.push([
+    "Trivy findings (gated severity)",
+    `${ok ? greenCheck : redX} ${trivy.total} (${bySev})`,
+  ]);
+}
+if (npmAudit) {
+  const total =
+    (npmAudit.high || 0) +
+    (npmAudit.critical || 0) +
+    (npmAudit.moderate || 0) +
+    (npmAudit.low || 0);
+  const ok = npmOk(npmAudit);
+  rows.push([
+    "npm audit (production)",
+    `${ok ? greenCheck : redX} ${total} (critical: ${npmAudit.critical || 0}, high: ${npmAudit.high || 0}, moderate: ${npmAudit.moderate || 0})`,
+  ]);
+}
+if (gitleaks) {
+  const ok = gitleaksOk(gitleaks);
+  rows.push([
+    "Gitleaks (secrets)",
+    `${ok ? greenCheck : redX} ${gitleaks.total} finding(s)`,
+  ]);
+}
+if (manifest) {
+  const ok = manifestOk(manifest);
+  rows.push([
+    "Evidence manifest",
+    `${ok ? greenCheck : redX} ${manifest.artifacts} artifact(s); ${manifest.missing} missing`,
+  ]);
+}
+
+if (rows.length > 0) {
+  sections.push("| Signal | Value |");
+  sections.push("| --- | --- |");
+  for (const [k, v] of rows) {
+    sections.push(`| ${k} | ${v} |`);
+  }
+  sections.push("");
+}
+
+if (runUrl) {
+  sections.push(`[Workflow run details](${runUrl}) — sign in to view logs and download artifacts.`);
+  sections.push("");
+}
+
+sections.push("_Updated automatically by the `pr-summary` job._");
+
+process.stdout.write(sections.join("\n") + "\n");


### PR DESCRIPTION
## Summary

Roadmap item **#3** from `docs/phone-testing-roadmap.md`: a sticky PR comment that collapses pipeline output into one phone-tappable screen. Solves the "everything's behind a log drill-down on desktop" problem from earlier sessions.

The first PR this lands on will get a comment looking like:

> **Status:** ✅ all signals green · `abc1234`
>
> | Signal | Value |
> | --- | --- |
> | Backend tests (Surefire) | ✅ 80 run, 0 failed, 0 errored, 0 skipped |
> | JaCoCo line coverage | 11.2% |
> | JaCoCo branch coverage | 1.8% |
> | E2E (Playwright, desktop + mobile) | ✅ 0 failed spec(s) |
> | Trivy findings (gated severity) | ✅ 0 (none) |
> | npm audit (production) | ✅ 0 (critical: 0, high: 0, moderate: 0) |
> | Gitleaks (secrets) | ✅ 0 finding(s) |
> | Evidence manifest | ✅ 10 artifact(s); 0 missing |

(or with red ❌ marks for any failing signal)

## What's added

### `scripts/pr-summary.mjs` (new)
Pure-Node ESM script, no external deps. Reads the directory that `actions/download-artifact` produces. Each parser is best-effort:

- Surefire `.txt` summaries — backend test counts
- JaCoCo `jacoco.xml` — line / branch coverage %
- `frontend-coverage/coverage-summary.json` — Karma + Istanbul
- `trivy-results.json` — by-severity counts (within the gated severity)
- `npm-audit.json` — critical / high / moderate
- `gitleaks-report.json` — finding count
- `evidence-manifest.json` — artifact + missing counts
- `playwright-test-results/` — failed-spec count

Smoke-tested locally with both an empty fixture (degenerate but valid output) and a populated fixture covering all signals.

### `.github/workflows/golden-pipeline.yml`
New `pr-summary` job:

- `if: always() && github.event_name == 'pull_request'` — runs on every PR even if upstream jobs failed (so the comment always reflects current state)
- `needs:` all six compliance jobs + `e2e`
- `permissions:` adds `pull-requests: write` (job-level)
- Downloads every artifact, runs the script, appends to `GITHUB_STEP_SUMMARY`, upserts a sticky PR comment via `marocchino/sticky-pull-request-comment@v3.0.4` (`0ea0beb6…`) with `header: pr-summary` so each PR has exactly one comment, edited in place

## Out of scope

- **GitLab MR-note mirror** — not in this PR. GitLab's path uses the project API + a CI variable token; mirror later if you want it on the MacBook side.
- **Bundle-size diff** — would need a baseline from master; deferred until/if there's an existing bundle-size baseline workflow.
- **Preview-deploy URL** — roadmap #2 isn't shipped yet; once it is, that link slots into this comment.

## Test plan

- [ ] PR check `pr-summary` runs on this PR and posts a comment within ~30s of upstream jobs finishing
- [ ] All ✅ signals (or accurate ❌ counts if anything goes red)
- [ ] Updating this PR (push a noop commit) **edits the same comment** rather than posting a second one
- [ ] On master push (no PR context), the job is skipped — no comment attempted

https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp

---
_Generated by [Claude Code](https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp)_