### PR TITLE
Publish HTML reports to GitHub Pages per PR (roadmap #5)

### DIFF
--- a/.github/workflows/golden-pipeline.yml
+++ b/.github/workflows/golden-pipeline.yml
@@ -589,6 +589,7 @@ jobs:
       - sbom
       - oscal
       - verify-evidence
+      - publish-pr-reports
     permissions:
       contents: read
       pull-requests: write
@@ -609,6 +610,9 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+          PUBLISH_PR_REPORTS_RESULT: ${{ needs.publish-pr-reports.result }}
         run: node scripts/pr-summary.mjs evidence/ > pr-summary.md
 
       - name: Append summary to step output
@@ -619,3 +623,67 @@ jobs:
         with:
           header: pr-summary
           path: pr-summary.md
+
+  publish-pr-reports:
+    name: Publish HTML reports to GitHub Pages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs:
+      - test
+      - e2e
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Download HTML report artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: incoming/
+          pattern: '{jacoco-report,frontend-coverage,playwright-html-report}'
+
+      # Reports live at gh-pages/pr/<N>/{jacoco,frontend-coverage,playwright}/
+      # so each open PR has a stable URL. keep_files: true on the publish
+      # step preserves other PRs' subtrees on the branch.
+      - name: Stage reports under pr/${{ github.event.pull_request.number }}/
+        run: |
+          set -e
+          dest="pr-reports/pr/${{ github.event.pull_request.number }}"
+          mkdir -p "$dest"
+          [ -d incoming/jacoco-report ] && cp -r incoming/jacoco-report "$dest/jacoco" || true
+          [ -d incoming/frontend-coverage ] && cp -r incoming/frontend-coverage "$dest/frontend-coverage" || true
+          [ -d incoming/playwright-html-report ] && cp -r incoming/playwright-html-report "$dest/playwright" || true
+          # Index page so the bare pr/<N>/ URL is browsable from a phone.
+          cat > "$dest/index.html" <<HTML
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width,initial-scale=1">
+          <title>PR #${{ github.event.pull_request.number }} reports</title>
+          <style>body{font-family:system-ui;margin:2rem;font-size:1.1rem}a{display:block;padding:.6rem 0}</style>
+          </head>
+          <body>
+          <h1>PR #${{ github.event.pull_request.number }} reports</h1>
+          <p>Commit <code>${GITHUB_SHA:0:7}</code></p>
+          <a href="jacoco/">JaCoCo backend coverage</a>
+          <a href="frontend-coverage/">Frontend (Karma + Istanbul) coverage</a>
+          <a href="playwright/">Playwright e2e HTML report</a>
+          </body>
+          </html>
+          HTML
+          ls -la "$dest"
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: pr-reports/
+          publish_branch: gh-pages
+          keep_files: true
+          commit_message: 'pr-reports: pr/${{ github.event.pull_request.number }} @ ${{ github.event.pull_request.head.sha }}'
+
+      - name: Emit audit event
+        if: always()
+        run: |
+          echo '{"event":"publish_pr_reports","severity":"info","status":"'"${{ job.status }}"'","pr":${{ github.event.pull_request.number }},"commit":"'"${{ github.sha }}"'","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'

--- a/scripts/pr-summary.mjs
+++ b/scripts/pr-summary.mjs
@@ -350,6 +350,25 @@ if (runUrl) {
   sections.push("");
 }
 
+// --- Per-PR Pages report links ----------------------------------------------
+
+const prNumber = process.env.PR_NUMBER;
+const pagesBase = (process.env.PAGES_BASE_URL || "").replace(/\/+$/, "");
+const publishResult = process.env.PUBLISH_PR_REPORTS_RESULT || "";
+
+if (prNumber && pagesBase && publishResult === "success") {
+  const root = `${pagesBase}/pr/${prNumber}`;
+  sections.push(
+    `**Reports:** [JaCoCo](${root}/jacoco/) · [Frontend coverage](${root}/frontend-coverage/) · [Playwright](${root}/playwright/) · [index](${root}/)`,
+  );
+  sections.push("");
+} else if (prNumber && pagesBase && publishResult && publishResult !== "skipped") {
+  sections.push(
+    `_Per-PR HTML reports unavailable (publish-pr-reports: \`${publishResult}\`). One-time setup: enable Pages on the \`gh-pages\` branch in repo settings._`,
+  );
+  sections.push("");
+}
+
 sections.push("_Updated automatically by the `pr-summary` job._");
 
 process.stdout.write(sections.join("\n") + "\n");


### PR DESCRIPTION
## Summary

Roadmap item **#5** — publish HTML reports to GitHub Pages per-PR. Each open PR gets a stable, mobile-Safari-browsable URL:

```
https://doolin.github.io/javasprang/pr/<N>/
  ├── jacoco/             — JaCoCo backend coverage
  ├── frontend-coverage/  — Karma + Istanbul
  ├── playwright/         — Playwright HTML report (desktop + mobile-safari runs)
  └── index.html          — small landing page with links
```

This pairs with the **PR summary comment bot (#3)**: the sticky comment now renders a "Reports:" line with the three links when the publish job succeeds, so a reviewer on a phone can tap straight from the PR comment into the rendered HTML.

## ⚠️ One-time setup required before this works

After merging:

1. Open repo **Settings → Pages**
2. Under **Source**, choose **Deploy from a branch** → **gh-pages** → **/ (root)**
3. Click **Save**

The `gh-pages` branch is created automatically by the first PR run. Pages serving the branch is the toggle that has to flip manually. Until that toggle is on, the report URLs will 404 and the PR summary bot will surface a one-time-setup hint instead of the link line.

## What's added

### `.github/workflows/golden-pipeline.yml`

- New `publish-pr-reports` job — runs only on PR events, after `test` + `e2e`. Uses `peaceiris/actions-gh-pages@v4.0.0` (`4f9cc6602d…`) with `keep_files: true` so each PR's subtree coexists on the branch.
- `pr-summary` job now `needs:` the publish job, threads `PR_NUMBER` + `PAGES_BASE_URL` + the publish result into the summary script.

### `scripts/pr-summary.mjs`

- Renders a `**Reports:** [JaCoCo](…) · [Frontend coverage](…) · [Playwright](…) · [index](…)` line when env vars are set and the publish job succeeded
- Renders a one-time-setup hint if the publish job failed for any reason other than `skipped`
- Smoke-tested locally: `PR_NUMBER=42 PAGES_BASE_URL=… PUBLISH_PR_REPORTS_RESULT=success node scripts/pr-summary.mjs <fixture>` produces the expected output

## Out of scope

- **Cleanup-on-close** — stale `pr/<N>/` subtrees aren't auto-removed when a PR closes. Each is small (KB to a few MB) and the `gh-pages` branch is git-history-pruneable, but a follow-up workflow on `pull_request: closed` would handle it cleanly.
- **GitLab mirror** — GitLab Pages has its own model; mirror later if needed.

## Test plan

- [ ] CI on this PR pushes its first batch of reports to a new `gh-pages` branch
- [ ] Enable Pages on the branch (steps above)
- [ ] On the next PR, the URL `https://doolin.github.io/javasprang/pr/<N>/` renders the index page with three working sub-links
- [ ] PR summary bot's sticky comment includes the Reports line
- [ ] Multiple open PRs publish without overwriting each other's subtrees

https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp

---
_Generated by [Claude Code](https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp)_