### PR TITLE
Add issue templates, CODEOWNERS, SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — automatic reviewer routing for pull requests.
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Single-maintainer placeholder. Patterns are last-match-wins; the
+# global owner below catches anything not covered by a more specific
+# rule. Expand by area when contributors / teams join.
+
+*                                       @doolin
+
+# Future area-scoped rules (uncomment + adjust handles when teams exist):
+# src/main/java/                        @doolin/backend-reviewers
+# src/main/frontend/                    @doolin/frontend-reviewers
+# .github/workflows/                    @doolin/ci-reviewers
+# .gitlab/                              @doolin/ci-reviewers
+# scripts/                              @doolin/ci-reviewers
+# docs/                                 @doolin/docs-reviewers
+# pom.xml                               @doolin/backend-reviewers
+# src/main/frontend/package.json        @doolin/frontend-reviewers
+# .trivyignore                          @doolin/security-reviewers

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something is broken
+title: "Bug: "
+labels:
+  - kind/bug
+  - status/needs-triage
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What's broken?
+      description: One- or two-sentence summary.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser / OS / commit SHA / CI run if applicable
+      placeholder: "iOS Safari 18.2; commit abc1234"
+  - type: input
+    id: run-url
+    attributes:
+      label: Related CI run URL (optional)
+      placeholder: "https://github.com/doolin/javasprang/actions/runs/..."
+  - type: dropdown
+    id: area
+    attributes:
+      label: Code/system area
+      description: Best-guess; will be retagged in triage.
+      options:
+        - backend
+        - frontend
+        - ci
+        - compliance
+        - security
+        - deps
+        - docs
+        - infra
+        - "(unsure)"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,29 @@
+name: Chore
+description: Housekeeping that doesn't change behavior (deps, build, refactor)
+title: "Chore: "
+labels:
+  - kind/chore
+  - status/needs-triage
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What needs doing?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Code/system area
+      options:
+        - backend
+        - frontend
+        - ci
+        - compliance
+        - security
+        - deps
+        - docs
+        - infra
+        - "(unsure)"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/compliance-finding.yml
+++ b/.github/ISSUE_TEMPLATE/compliance-finding.yml
@@ -1,0 +1,90 @@
+name: Compliance finding
+description: Track a CVE, control gap, or audit observation through to closure
+title: "Compliance: "
+labels:
+  - kind/compliance
+  - status/needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for findings that need a tracked decision —
+        not for transient pipeline output (those live in CI logs and
+        evidence artifacts) and not for suppressed CVEs (those live in
+        `.trivyignore` with their justification + removal condition).
+  - type: dropdown
+    id: source
+    attributes:
+      label: Finding source
+      options:
+        - trivy
+        - npm-audit
+        - gitleaks
+        - oscal-assessment
+        - external-audit
+        - manual-review
+        - other
+    validations:
+      required: true
+  - type: input
+    id: external-id
+    attributes:
+      label: CVE or control ID (if any)
+      placeholder: "CVE-2026-22732 or NIST AC-2"
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+        - n/a
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the finding? Where does it surface?
+    validations:
+      required: true
+  - type: dropdown
+    id: decision
+    attributes:
+      label: Decision
+      options:
+        - remediate (will fix in this ticket)
+        - suppress-with-justification (.trivyignore-style)
+        - defer (track for later remediation)
+        - accept-risk (document and close)
+    validations:
+      required: true
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: Required for suppress / defer / accept-risk. Why is this the right call?
+  - type: textarea
+    id: removal-condition
+    attributes:
+      label: Removal / re-evaluation condition
+      description: If suppress or defer, what change would let us close this gap?
+      placeholder: "e.g. Spring Boot 3 migration; vendor patch; framework version bump"
+  - type: dropdown
+    id: control-mapping
+    attributes:
+      label: Compliance control (apply matching label after creation)
+      options:
+        - "ssdf-pw.4 (SBOM)"
+        - "ssdf-pw.6 (secrets scan)"
+        - "ssdf-pw.7 (vuln scan, source)"
+        - "ssdf-pw.8 (vuln scan, executable)"
+        - "ssdf-ps.1 (provenance)"
+        - "ssdf-ps.2 (verification)"
+        - "m-21-31 (logging)"
+        - "m-22-18 (self-attestation)"
+        - "m-24-15 (OSCAL)"
+        - "eo-14028 (supply chain)"
+        - "n/a"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability disclosure
+    url: https://github.com/doolin/javasprang/security/advisories/new
+    about: Use GitHub Security Advisories for private disclosure. Do not file a public issue for security findings.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: New capability for users or the platform
+title: "Feature: "
+labels:
+  - kind/feature
+  - status/needs-triage
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user need or system gap motivates this?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? Sketch is fine.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: How do we know we're done? Bullet list.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Code/system area
+      options:
+        - backend
+        - frontend
+        - ci
+        - compliance
+        - security
+        - deps
+        - docs
+        - infra
+        - "(unsure)"
+    validations:
+      required: true
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain (if user-facing)
+      options:
+        - auth
+        - todo
+        - kanban
+        - evidence
+        - attestation
+        - n/a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security finding.**
+
+Use [GitHub Security Advisories — "Report a vulnerability"][gha] to
+disclose privately. The maintainer is notified by email and the
+advisory stays private until coordinated disclosure.
+
+[gha]: https://github.com/doolin/javasprang/security/advisories/new
+
+If GitHub Security Advisories isn't usable for you, open a *blank* PR
+in your own fork (no description, no patch) and link to it from a
+generic communication channel — we'll coordinate offline from there.
+
+## Scope
+
+In scope:
+
+- The Java / Spring Boot backend (`src/main/java/`)
+- The Angular frontend (`src/main/frontend/`)
+- The CI/CD pipeline (`.github/workflows/`, `.gitlab/`, `scripts/`)
+- Compliance evidence outputs (SBOM, OSCAL, attestation)
+- Dependency-tree CVEs not already documented in `.trivyignore`
+
+Out of scope:
+
+- Third-party hosted services (GitHub, GitLab, runners)
+- Findings already documented in `.trivyignore` with a published
+  removal condition
+- Demo / synthetic data populated by `scripts/provision_synthetic_data.sh`
+
+## What to expect
+
+- Acknowledgement of receipt within ~2 business days (best-effort;
+  this is a single-maintainer OSS project)
+- Coordinated disclosure timeline negotiated based on severity and
+  fix complexity
+- Credit in release notes if you'd like
+
+## How findings are tracked
+
+Confirmed findings are tracked through the project's normal compliance
+workflow (see [`docs/ticket-conventions.md`](./docs/ticket-conventions.md)).
+Each finding gets a ticket with:
+
+- Source (`trivy`, `npm-audit`, `gitleaks`, `external-audit`, etc.)
+- Severity, CVE/control ID, decision, justification, removal condition
+- Mapping to the relevant SSDF / OMB control via `compliance/*` labels
+
+Suppressed CVEs are documented inline in `.trivyignore` with their own
+justification and removal condition.
+
+## Security pipeline
+
+The CI/CD pipeline runs on every PR and emits machine-readable
+evidence:
+
+- **gitleaks** — secrets scan over full git history (PW.6)
+- **npm audit** — production-tree advisories (PW.7)
+- **Trivy** — filesystem scan (PW.7 / PW.8)
+- **anchore syft** — CycloneDX SBOM (PW.4)
+- **OSCAL artifacts** — assessment results, component definition,
+  SSP fragment (M-24-15)
+- **SLSA build provenance + RFC 3161 timestamp** — main-branch only
+
+Evidence is retained 90 days as artifacts and indefinitely on the
+project's S3 compliance bucket once the deploy gate is wired.


### PR DESCRIPTION
## Summary

PR 2 of the ticket-structure proposal. Connects contributors to the taxonomy bootstrapped in PR 1 via structured issue forms, reviewer routing, and a security disclosure policy.

## What's added

### Issue templates (`.github/ISSUE_TEMPLATE/`)

YAML form syntax — mobile-friendly, structured fields, auto-applies labels.

| Template | Auto-labels | Required fields |
| --- | --- | --- |
| `bug.yml` | `kind/bug`, `status/needs-triage` | description, repro, expected, actual, area |
| `feature.yml` | `kind/feature`, `status/needs-triage` | problem, proposal, acceptance criteria, area |
| `compliance-finding.yml` | `kind/compliance`, `status/needs-triage` | source, severity, description, decision (remediate / suppress / defer / accept-risk) |
| `chore.yml` | `kind/chore`, `status/needs-triage` | description, area |
| `config.yml` | — | Disables blank issues; routes security to GHSA |

The **compliance-finding** form is purpose-built for tracking CVEs and control gaps to closure with explicit `decision` + `justification` + `removal-condition` fields, mirroring the same shape as `.trivyignore` entries. Pairs with the `compliance/*` axis from PR 1 — apply the matching label after creation.

### `.github/CODEOWNERS`

Single-maintainer placeholder (`* @doolin`) with commented-out scaffolding for area-scoped rules to expand into when reviewers or teams join. Patterns are last-match-wins.

### `SECURITY.md`

Disclosure policy:
- Routes private disclosure to **GitHub Security Advisories**
- In-scope: backend / frontend / CI / compliance pipeline / dep-tree CVEs
- Out-of-scope: third-party services, already-suppressed CVEs in `.trivyignore`, demo/synthetic data
- ~2-business-day acknowledgement, coordinated-disclosure timeline by severity
- Documents how confirmed findings flow through the compliance-finding template + `.trivyignore` + pipeline evidence emissions

## Verification

All five issue-template YAML files parse cleanly under PyYAML.

## Out of scope (PR 3)

Project board (Projects v2) — custom fields + saved views. Manual GUI setup documented in `docs/ticket-conventions.md` from PR 1.

## Test plan

- [ ] All Golden Pipeline stages green (no functional change)
- [ ] After merge: open a new issue → 4 template choices visible + "Security disclosure" contact link in the chooser
- [ ] Each form's required fields enforce; auto-labels apply
- [ ] Opening a PR shows `@doolin` as suggested reviewer (CODEOWNERS catch-all)
- [ ] Repo's Security tab links to a working "Report a vulnerability" workflow

https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp

---
_Generated by [Claude Code](https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp)_