### PR TITLE
Fix workflow startup failure: caller permissions must bound nested jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,10 +13,11 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   attestations: write
   security-events: write
+  pull-requests: write
 
 jobs:
   compliance:
@@ -31,10 +32,18 @@ jobs:
       # the baseline is clean.
       trivy-severity: "CRITICAL"
     permissions:
-      contents: read
+      # Caller bounds: must include the union of permissions any nested
+      # job in golden-pipeline.yml requests, even for jobs gated `if:`
+      # off on this run — GitHub validates at workflow parse time, not
+      # runtime. publish-pr-reports needs contents:write (push to
+      # gh-pages); pr-summary needs pull-requests:write (sticky PR
+      # comment). Both are gated to PR events but their permission
+      # blocks must still fit here.
+      contents: write
       id-token: write
       attestations: write
       security-events: write
+      pull-requests: write
     secrets: inherit
 
   package:


### PR DESCRIPTION
## Summary

Master-push CI run **#102** (commit `06f1112b`) failed at startup with:

> The nested job `pr-summary` is requesting `pull-requests: write`, but is only allowed `pull-requests: none`.
> The nested job `publish-pr-reports` is requesting `contents: write`, but is only allowed `contents: read`.

## Root cause

GitHub validates a reusable-workflow caller's permission bounds at **workflow parse time**, not runtime. Even though both `pr-summary` and `publish-pr-reports` are gated `if: github.event_name == 'pull_request'` and skip on master push, their declared `permissions:` blocks still have to fit within the caller's allowed set — or the **entire run** is rejected before any job starts.

The reusable workflow's needs:
- `pr-summary` → `pull-requests: write` (sticky PR comment)
- `publish-pr-reports` → `contents: write` (push to `gh-pages` branch)

The caller `ci-cd.yml` was declaring `contents: read` and didn't mention `pull-requests` at all.

## Fix

Bump both the top-level and the `compliance` job's permissions:

```diff
permissions:
- contents: read
+ contents: write
  id-token: write
  attestations: write
  security-events: write
+ pull-requests: write
```

Same change in `jobs.compliance.permissions:`. Added an inline comment explaining the parse-time constraint so future nested-job permission additions don't trip the same wire.

## Why PR events weren't affected

The `pull_request:` trigger is filtered to `branches: [main]` (line 13). The repo's default is `master`, so PR events never fire — runs on PRs use the `push:` event instead, which has the same permission set as master push. **PR runs and master runs use the same code path**, so the fix applies to both.

## Test plan

- [ ] On this PR, the workflow starts cleanly (no "startup failure")
- [ ] After merge: master-push CI run #N goes green; `package` and `attest` jobs execute as before; `pr-summary` and `publish-pr-reports` are still skipped (gated on `github.event_name == 'pull_request'`, which doesn't fire because of the `branches: [main]` filter — separate cleanup if you want PR events for master)
- [ ] The next PR's CI runs through pr-summary + publish-pr-reports without permission errors

## Optional follow-up

The `branches: [main]` filter on the `pull_request:` trigger is dead code for this repo. Either remove it (so the trigger fires for any PR) or change to `[master]` (so it fires for master-targeted PRs). Right now PR runs only happen because of the push event — which works, but means the `pull_request` event context is never available, and several `${{ github.event.pull_request.* }}` expressions degrade silently. Worth a separate small PR.

https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp

---
_Generated by [Claude Code](https://claude.ai/code/session_011b92pWJnt2R3uoSAJ9FcDp)_