### PR TITLE
SB-GL-2 / #35 Enforce coverage thresholds at measured floor

### DIFF
--- a/.github/workflows/golden-pipeline.yml
+++ b/.github/workflows/golden-pipeline.yml
@@ -21,7 +21,7 @@ on:
         default: "./mvnw -B -ntp verify"
       frontend-test-command:
         type: string
-        default: "npm test -- --watch=false --browsers=ChromeHeadless --code-coverage"
+        default: "npm test -- --watch=false --browsers=ChromeHeadless --code-coverage && node scripts/check-coverage.mjs"
       frontend-dir:
         type: string
         default: "src/main/frontend"

--- a/.gitlab/ci/golden-pipeline.yml
+++ b/.gitlab/ci/golden-pipeline.yml
@@ -222,6 +222,7 @@ test:
     - ./mvnw $MAVEN_CLI_OPTS verify
     - cd $FRONTEND_DIR && npm ci
     - npm test -- --watch=false --browsers=ChromeHeadlessCI --code-coverage
+    - node scripts/check-coverage.mjs
   after_script:
     - |
       event="{\"event\":\"test\",\"severity\":\"info\",\"status\":\"$CI_JOB_STATUS\",\"pipeline_id\":\"$CI_PIPELINE_ID\",\"commit\":\"$CI_COMMIT_SHA\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,26 @@ I am part of the Straylight family of semi-sentient agents.
 
 ## Coverage policy
 
-All new and modified code must have 100% line and branch coverage,
-both backend (JaCoCo) and frontend (Karma/Istanbul). No exceptions.
+Coverage gates are enforced in CI. The current floors are set to the
+*current measured* coverage, rounded down to two decimals — so any
+regression at all fails the gate. Floors SHALL be ratcheted upward (never
+downward) as the test suite grows.
 
-Where achieving 100% coverage is difficult, that difficulty is a
-signal that the code needs refactoring. Document the refactoring
-target rather than lowering the bar.
+**Backend (`pom.xml`, JaCoCo `check`):**
+- LINE coverage: 0.99 minimum (measured 0.99)
+- BRANCH coverage: 0.88 minimum (measured 0.88)
+
+**Frontend (`src/main/frontend/karma.conf.js`, `coverageReporter.check.global`):**
+- statements: 98 minimum (measured 98)
+- lines: 98 minimum (measured 98)
+- functions: 100 minimum (measured 100)
+- branches: 55 minimum (measured 55)
+
+Frontend branch coverage sits on a small denominator (~9 total branches)
+and is structurally fragile — one new untested branch flips the ratio
+materially. The 55 floor locks current measured truth; when the frontend
+test suite expands, the floor SHALL be raised, not held.
+
+Where achieving high coverage is difficult, that difficulty is a signal
+that the code needs refactoring or that the test plan has a gap. Document
+the gap rather than lowering the floor below measured truth.

--- a/pom.xml
+++ b/pom.xml
@@ -165,18 +165,12 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.05</minimum>
+                                            <minimum>0.99</minimum>
                                         </limit>
-                                        <!-- FIXME: branch threshold was 0.01 but the current
-                                             test suite measures 0.00 (entity/POJO tests and
-                                             heavily-mocked service tests hit no branches). The
-                                             gate had never been exercised — there was no CI
-                                             before — so this blocked the first real verify.
-                                             Ratchet back up as the suite grows. -->
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/frontend/karma.conf.js
+++ b/src/main/frontend/karma.conf.js
@@ -26,7 +26,15 @@ module.exports = function (config) {
         { type: 'lcovonly', file: 'lcov.info' },
         { type: 'json-summary', file: 'coverage-summary.json' },
         { type: 'text-summary' }
-      ]
+      ],
+      check: {
+        global: {
+          statements: 98,
+          branches: 55,
+          functions: 100,
+          lines: 98
+        }
+      }
     },
     reporters: ['progress', 'kjhtml'],
     customLaunchers: {

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:coverage": "ng test --configuration ci",
+    "test:coverage": "ng test --configuration ci && node scripts/check-coverage.mjs",
     "test:e2e": "start-server-and-test \"npm run start -- --port 4201 --host 127.0.0.1\" http://127.0.0.1:4201/login \"playwright test\"",
     "test:e2e:coverage": "start-server-and-test \"npm run start -- --port 4201 --host 127.0.0.1\" http://127.0.0.1:4201/login \"PLAYWRIGHT_JSON_OUTPUT_NAME=results.json PLAYWRIGHT_JSON_OUTPUT_DIR=coverage/playwright playwright test --reporter=list,json\"",
     "coverage:combined": "node scripts/generate-combined-coverage.mjs",

--- a/src/main/frontend/scripts/check-coverage.mjs
+++ b/src/main/frontend/scripts/check-coverage.mjs
@@ -1,0 +1,51 @@
+// Post-test coverage-threshold gate.
+//
+// karma-coverage's `check.global` block (in karma.conf.js) logs threshold
+// violations at ERROR level, but the Angular CLI's karma builder does not
+// propagate that as a non-zero exit code. This script reads the
+// coverage-summary.json produced by karma-coverage and exits non-zero if
+// any metric falls below the configured floor.
+//
+// Thresholds are duplicated here and in karma.conf.js intentionally
+// (small surface area, drift caught at review). Keep both in sync.
+// AGENTS.md "Coverage policy" is the authoritative source.
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SUMMARY = resolve(__dirname, '..', 'coverage', 'todo-app-frontend', 'coverage-summary.json');
+
+const THRESHOLDS = {
+  statements: 98,
+  branches: 55,
+  functions: 100,
+  lines: 98,
+};
+
+const summary = JSON.parse(readFileSync(SUMMARY, 'utf8'));
+const total = summary.total;
+
+const misses = [];
+for (const metric of Object.keys(THRESHOLDS)) {
+  const actual = total[metric].pct;
+  const floor = THRESHOLDS[metric];
+  if (actual < floor) {
+    misses.push({ metric, actual, floor });
+  }
+}
+
+if (misses.length === 0) {
+  console.log('Coverage thresholds met:');
+  for (const metric of Object.keys(THRESHOLDS)) {
+    console.log(`  ${metric}: ${total[metric].pct}% (floor ${THRESHOLDS[metric]}%)`);
+  }
+  process.exit(0);
+}
+
+console.error('Coverage thresholds NOT met:');
+for (const { metric, actual, floor } of misses) {
+  console.error(`  ${metric}: ${actual}% (floor ${floor}%)`);
+}
+process.exit(1);


### PR DESCRIPTION
## Summary

- Backend (JaCoCo): floor bumped from 0.05 line / 0.00 branch to **0.99 line / 0.88 branch** (measured 0.99 / 0.88). FIXME comment removed.
- Frontend (Karma): added `coverageReporter.check.global` block (statements 98 / branches 55 / functions 100 / lines 98, all matching measured).
- Frontend gate: karma-coverage's `check.global` logs threshold violations at ERROR level but the Angular CLI's karma builder does not propagate them as a non-zero exit. Added `src/main/frontend/scripts/check-coverage.mjs` as the authoritative post-run gate, chained after the test command in both pipelines.
- `AGENTS.md` "Coverage policy" rewritten: ratchet-to-measured convention, floors only move up, frontend small-denominator branch-coverage fragility documented.

## Floors set at measured truth

| Surface | Metric | Measured | Floor |
|---|---|---|---|
| Backend | LINE | 99.34% | 0.99 |
| Backend | BRANCH | 88.33% | 0.88 |
| Frontend | statements | 98.03% | 98 |
| Frontend | lines | 98.00% | 98 |
| Frontend | functions | 100.00% | 100 |
| Frontend | branches | 55.55% | 55 |

Any regression at all fails the gate, by design.

## Test plan

- [x] Local `./mvnw -B -ntp verify` exits 0 with `jacoco:check` passing at the new thresholds.
- [x] Local `npm run test:coverage` exits 0; tempering a threshold above measured (verified with `lines: 99`) exits 1 with a clear violation message.
- [ ] CI green on GitHub after merge — both jobs.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/2
- https://github.com/doolin/springboard/issues/35