### PR TITLE
SB-GL-46 Fix gitlab-issue-create.sh search step

### DIFF
--- a/scripts/gitlab-issue-create.sh
+++ b/scripts/gitlab-issue-create.sh
@@ -80,13 +80,18 @@ fi
 
 # search_by_title: emit the .web_url of an exact-title match (or empty).
 # Uses --search (substring/fuzzy) then filters to exact title match via jq.
+# `--all` includes both open and closed issues; without it `glab issue list`
+# defaults to open-only, which would miss closed duplicates and lead to
+# duplicate-creation if a previously-closed ticket has the same title.
+# stderr is intentionally NOT suppressed — a glab flag-syntax error must
+# surface immediately rather than silently kill the script (SB-GL-46).
 search_by_title() {
   local title="$1"
   glab issue list \
     --repo "$REPO" \
     --search "$title" \
-    --state all \
-    --output json 2>/dev/null \
+    --all \
+    --output json \
     | jq -r --arg t "$title" '
         if type == "array" then
           [.[] | select(.title == $t)] | sort_by(.iid) | .[0].web_url // empty


### PR DESCRIPTION
## Summary

`scripts/gitlab-issue-create.sh` (landed in SB-GL-25 as the canonical search-before-create helper that prevents the INC-2026-05-12-001 duplicate-issue pattern) was non-functional from the moment it landed:

- Search step used `--state all` — not a valid `glab issue list` flag (correct: `--all`).
- `2>/dev/null` on the search invocation suppressed the resulting `Unknown flag` error.
- `set -euo pipefail` then killed the script silently before the create step could run.

Effect: agents have been falling back to direct `glab issue create` invocation, with no verify-before-retry guardrail. The exact failure-mode the helper was designed to prevent.

## Fix

- Replace `--state all` with `--all`. Closed duplicates must also be detected — a previously-closed ticket sharing a title would otherwise be recreated.
- Remove `2>/dev/null` from the search step. glab flag drift must surface immediately, not silently kill the script.
- Add comments explaining both choices.

## Verified

```
$ scripts/gitlab-issue-create.sh --title "Untrack .claude/settings.local.json — gitignore can't retroactively ignore tracked files" --description-file /tmp/test-body.md
Searching for existing issue with title: Untrack .claude/settings.local.json — gitignore can't retroactively ignore tracked files
Existing issue found; not creating a duplicate.
https://gitlab.com/doolin/springboard/-/work_items/45
exit=0
```

## Test plan

- [x] End-to-end run against existing ticket title returns its URL and exits 0 (no duplicate).
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/46
- https://gitlab.com/doolin/springboard/-/work_items/25 (incident report this helper was built to prevent recurrence of)