### PR TITLE
SB-GL-27 Suppress logback HIGH CVE cluster (2 CVEs) with config-absence verification

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -72,3 +72,40 @@ CVE-2024-38819
 # this codebase, so the exploitable surface is absent.
 # Fix: 6.1.13+. Removal: SB-GL-39 Spring Boot 3 migration.
 CVE-2024-38816
+
+# --- SB-GL-27: logback BOM-locked cluster (2 CVEs) ---
+# Both CVEs are pinned to logback 1.2.13, the terminal release of the
+# 1.2.x line. Spring Boot 2.7 BOM pins logback 1.2.x; no backport.
+# Authoritative remediation is the Spring Boot 2.7 → 3.x migration
+# tracked at SB-GL-39 (which pulls in logback 1.5.x).
+# Audited 2026-05-13. Quarterly review due 2026-08-13.
+#
+# Config audit (applies to BOTH CVEs below):
+#  - No `logback-spring.xml` / `logback.xml` in src/main/resources.
+#    The application uses Spring Boot's default logback configuration
+#    driven solely by `logging.level.*` properties in
+#    application.properties — no custom appenders, receivers, or
+#    JMX exposure.
+#  - `grep -rn "SocketReceiver|JMXConfigurator" src/` returns zero
+#    matches in application code or config (the only hits are unrelated
+#    JS WebSocketReceiver code in src/main/frontend/node_modules/sockjs).
+#  - Neither exploit precondition (a remote SocketReceiver appender; a
+#    JMX-exposed reconfiguration endpoint) can be reached.
+
+# CVE-2023-6378 — logback-classic 1.2.13
+# DoS via malformed serialized configuration messages to a
+# `SocketReceiver` appender. Exploitable only if logback XML configures
+# `<receiver class="ch.qos.logback.classic.net.SocketReceiver">`.
+# Audit: no logback XML, no SocketReceiver — exploitable surface absent.
+# Fix: 1.3.12+ / 1.4.12+. Removal: SB-GL-39 Spring Boot 3 migration.
+CVE-2023-6378
+
+# CVE-2023-6481 — logback-classic 1.2.13
+# RCE via serialization gadget chain in `SaxEventRecorder`, exploitable
+# only if `JMXConfigurator` or an HTTP reconfiguration endpoint accepts
+# crafted XML from an attacker.
+# Audit: no JMXConfigurator, no logback reconfiguration endpoint — Spring
+# Boot does not expose this by default and this application does not
+# enable it. Exploitable surface absent.
+# Fix: 1.3.12+ / 1.4.12+. Removal: SB-GL-39 Spring Boot 3 migration.
+CVE-2023-6481


### PR DESCRIPTION
## Summary

Suppresses 2 logback HIGH CVEs (CVE-2023-6378 DoS, CVE-2023-6481 RCE) called out in the SB-GL-3 dossier ([sub-cluster B](https://gitlab.com/doolin/springboard/-/blob/master/docs/compliance/research/2026-05-12-cve-dossier.md)). Both are pinned to logback 1.2.13 (terminal 1.2.x); fix is 1.3.12+ / 1.4.12+ which requires a major upgrade. Authoritative remediation is [SB-GL-39](https://gitlab.com/doolin/springboard/-/work_items/39).

## Config audit

| CVE | Exploit precondition | Audit | Result |
|---|---|---|---|
| CVE-2023-6378 | `<receiver class="ch.qos.logback.classic.net.SocketReceiver">` configured | `find src/main/resources -name "logback*"` | **zero files** (no logback XML at all) |
| CVE-2023-6481 | `JMXConfigurator` or HTTP reconfiguration endpoint exposed | `grep -rn "SocketReceiver\|JMXConfigurator" src/` | **zero matches** in app code/config (only unrelated JS WebSocketReceiver hits in `node_modules/sockjs`) |

The application uses Spring Boot's default logback configuration driven solely by `logging.level.*` properties in `application.properties` — no custom appenders, no receivers, no JMX exposure. Neither exploit precondition can be reached.

## Dossier-vs-current-Trivy note

Same drift pattern as SB-GL-26: local Trivy 0.70.0 against current master does not surface CVE-2023-6378 or CVE-2023-6481 (the CVE DB has evolved since the 2026-05-12 dossier). The suppression entries are documented compliance evidence ([SP 800-53 SI-2](https://doi.org/10.6028/NIST.SP.800-53r5), [SP 800-218](https://doi.org/10.6028/NIST.SP.800-218) RV.1) regardless of whether the CVE is on Trivy's current table — the rationale was documented in the walkthrough as part of SB-GL-26.

## Test plan

- [x] `.trivyignore` syntax accepted by Trivy 0.70.0 locally.
- [x] Both audit greps confirmed zero matches.
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/27
- https://gitlab.com/doolin/springboard/-/work_items/3
- https://gitlab.com/doolin/springboard/-/work_items/39