### PR TITLE
SB-GL-28 Suppress jackson-databind HIGH cluster (2 CVEs) — audit + compensating control

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -109,3 +109,40 @@ CVE-2023-6378
 # enable it. Exploitable surface absent.
 # Fix: 1.3.12+ / 1.4.12+. Removal: SB-GL-39 Spring Boot 3 migration.
 CVE-2023-6481
+
+# --- SB-GL-28: jackson-databind BOM-locked cluster (2 CVEs) ---
+# Both CVEs are pinned to jackson-databind 2.13.5, the terminal release
+# of the 2.13.x line. Spring Boot 2.7 BOM pins jackson 2.13.x; no 2.13.x
+# backport for either CVE. Authoritative remediation is the Spring Boot
+# 2.7 → 3.x migration tracked at SB-GL-39 (which pulls in jackson 2.15+).
+# Audited 2026-05-13. Quarterly review due 2026-08-13.
+
+# CVE-2024-49338 — jackson-databind 2.13.5
+# Unsafe deserialization when polymorphic type handling (default-typing)
+# is active and an attacker can supply type metadata in the JSON payload.
+# Audit: `grep -rn "enableDefaultTyping\|activateDefaultTyping\|DefaultTyping\|PolymorphicTypeValidator" src/main/java/`
+# returns zero matches. No custom `ObjectMapper` beans. The application
+# uses Spring Boot's default ObjectMapper with explicit type bindings only
+# (@RestController + @RequestBody DTO classes); polymorphic deserialization
+# is never enabled, so attacker-supplied type metadata has no effect.
+# Fix: no 2.13.x backport. Removal: SB-GL-39 Spring Boot 3 migration.
+CVE-2024-49338
+
+# CVE-2023-35116 — jackson-databind 2.13.5
+# NVD-disputed DoS via deeply-nested JSON or oversized object graphs.
+# The Jackson maintainers dispute this finding (https://github.com/
+# FasterXML/jackson-databind/issues/3972) — the project's position is
+# that resource bounds at the HTTP layer are the proper mitigation, not
+# a Jackson code change. Accept-risk + compensating control rather than
+# pure suppress-with-justification.
+# Compensating control: `server.tomcat.max-http-post-size=2MB` and
+# `server.tomcat.max-http-form-post-size=2MB` set explicitly in
+# src/main/resources/application.properties. Any payload exceeding 2MB
+# is rejected by the container before reaching Jackson, bounding the
+# deserialization-resource impact at the boundary.
+# Decision authority: documented per SP 800-37 risk-acceptance process;
+# interim AO acknowledgement via SB-GL-28 ticket discussion.
+# Removal: when (a) NVD reverses the dispute (then re-evaluate fix
+# requirement) or (b) SB-GL-39 Spring Boot 3 migration brings jackson
+# 2.15+ which has the requested guards.
+CVE-2023-35116

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,13 @@
 # Server Configuration
 server.port=8081
 
+# Request body size limits — compensating control for jackson-databind
+# CVE-2023-35116 (NVD-disputed DoS via deeply-nested / oversized JSON).
+# Spring Boot's implicit default is 2MB; setting explicitly so the
+# control is discoverable in evidence reviews. See SB-GL-28.
+server.tomcat.max-http-post-size=2MB
+server.tomcat.max-http-form-post-size=2MB
+
 # Static Resource Configuration
 spring.web.resources.static-locations=classpath:/static/
 spring.mvc.static-path-pattern=/**


### PR DESCRIPTION
## Summary

Suppresses 2 jackson-databind HIGH CVEs called out in the SB-GL-3 dossier ([sub-cluster C](https://gitlab.com/doolin/springboard/-/blob/master/docs/compliance/research/2026-05-12-cve-dossier.md)). Both are pinned to jackson-databind 2.13.5 (terminal 2.13.x); fix is 2.14.3+ / 2.15.4+ which requires moving off Spring Boot 2.7's BOM. Authoritative remediation: [SB-GL-39](https://gitlab.com/doolin/springboard/-/work_items/39).

## CVE-2024-49338 — clean suppress-with-justification

Unsafe deserialization when polymorphic type handling (default-typing) is enabled.

| Audit | Result |
|---|---|
| `grep -rn "enableDefaultTyping\|activateDefaultTyping\|DefaultTyping\|PolymorphicTypeValidator" src/main/java/` | **zero matches** |
| Custom `ObjectMapper` beans | **none** |
| Default Spring Boot ObjectMapper, `@RestController` + `@RequestBody DTO` | explicit type bindings only |

Polymorphic deserialization is never enabled — attacker-supplied type metadata has no effect.

## CVE-2023-35116 — accept-risk + compensating control

NVD-disputed DoS via deeply-nested / oversized JSON. Jackson maintainers' [position](https://github.com/FasterXML/jackson-databind/issues/3972) is that resource bounds at the HTTP layer are the proper mitigation.

**Compensating control added** (`src/main/resources/application.properties`):

```properties
server.tomcat.max-http-post-size=2MB
server.tomcat.max-http-form-post-size=2MB
```

These match Spring Boot's implicit defaults but are now set explicitly so the control is discoverable in evidence reviews. Payloads exceeding 2MB are rejected by the container before reaching Jackson, bounding deserialization-resource impact at the request boundary. Decision pathway documented per [SP 800-37](https://csrc.nist.gov/pubs/sp/800/37/r2/final) risk-acceptance process; interim AO acknowledgement attaches to the SB-GL-28 ticket discussion.

## Test plan

- [x] `./mvnw -B -ntp verify` passes — 128 tests, JaCoCo gate met (the compensating-control property doesn't affect tests).
- [x] `.trivyignore` syntax accepted by Trivy 0.70.0 locally.
- [x] Both audit greps confirmed zero matches.
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/28
- https://gitlab.com/doolin/springboard/-/work_items/3
- https://gitlab.com/doolin/springboard/-/work_items/39
- https://github.com/FasterXML/jackson-databind/issues/3972 (CVE-2023-35116 maintainer dispute)