### PR TITLE
SB-GL-47 Bump postgresql 42.7.10 → 42.7.11 to remediate CVE-2026-42198

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <tomcat.version>9.0.117</tomcat.version>
         <logback.version>1.2.13</logback.version>
         <snakeyaml.version>2.6</snakeyaml.version>
-        <postgresql.version>42.7.10</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

CVE-2026-42198 (jdbc.postgresql.org pgjdbc: Client-side Denial of Service, HIGH) is fixed in the 42.7.11 patch release of the current major line. True remediation, not suppression.

Spring Boot 2.7's BOM does not pin postgresql, and our `pom.xml` override at `<postgresql.version>` was already on the 42.7.x line — so the bump is a 1-line patch-version increment with no compatibility risk.

## Verified

| Check | Result |
|---|---|
| `./mvnw -B -ntp verify` | passes (128 tests, JaCoCo gate met) |
| Local `trivy fs --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore .` | finding count drops 6 → 5; CVE-2026-42198 no longer surfaces |

No `.trivyignore` entry — vulnerability is removed at the dependency level.

## Test plan

- [x] Build green locally.
- [x] Trivy delta confirmed.
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/47