### PR TITLE
SB-GL-49 Suppress spring-core CVE-2025-41249 — audit + suppress (commercial-only fix)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -185,3 +185,28 @@ CVE-2025-22235
 # the predictable-temp-dir attack surface is absent.
 # Fix: spring-boot 3.5.14 / 4.0.6. Removal: SB-GL-39 Spring Boot 3 migration.
 CVE-2026-40973
+
+# CVE-2025-41249 — spring-core 5.3.39 (SB-GL-49)
+# Spring Framework annotation-detection mechanism may not correctly
+# resolve security annotations on methods within type hierarchies that
+# have a parameterized super type with unbounded generics. When such
+# annotations are used for authorization decisions, the check can be
+# silently skipped — authorization bypass.
+# Exploit requires: (1) `@EnableMethodSecurity` (or the deprecated
+# `@EnableGlobalMethodSecurity`), (2) security annotations like
+# `@PreAuthorize`/`@PostAuthorize`/`@Secured`/`@RolesAllowed` placed on
+# methods of generic superclasses or interfaces.
+# Audit: `grep -rn "@EnableMethodSecurity\|@EnableGlobalMethodSecurity\|
+# @PreAuthorize\|@PostAuthorize\|@Secured\|@RolesAllowed" src/main/java/`
+# returns zero matches. This application does NOT use method-level
+# security at all — security is enforced exclusively via the
+# `HttpSecurity.authorizeHttpRequests(...)` request-matcher chain in
+# SecurityConfig. The annotation-resolution code path is never invoked.
+# Fix: spring-framework 5.3.45 / 6.1.23 / 6.2.11. The 5.3.45 release
+# exists in VMware Tanzu Spring Runtime (commercial / enterprise feed)
+# but is NOT published to public Maven Central; verified
+# `mvn dependency:resolve` for `spring-framework-bom:5.3.45` returns
+# `Non-resolvable import POM`. Public Maven Central paths are closed
+# until Spring Boot 3.x migration.
+# Removal: SB-GL-39 Spring Boot 3 migration (pulls in 6.2.x line).
+CVE-2025-41249


### PR DESCRIPTION
## Summary

CVE-2025-41249 (spring-core annotation-detection failure on parameterized supertypes — authorization bypass risk) — fix advertised in 5.3.45 / 6.1.23 / 6.2.11.

**Attempted bump path failed**: `org.springframework:spring-framework-bom:5.3.45` is not in public Maven Central. Verified locally:

```
[ERROR] Non-resolvable import POM: spring-framework-bom:pom:5.3.45 (absent)
```

The 5.3.45 release exists in VMware Tanzu Spring Runtime (commercial / enterprise feed) but is not on Central — same situation as `spring-security-bom:5.7.16` documented in [SB-GL-50](https://gitlab.com/doolin/springboard/-/work_items/50). Public bump paths are closed until [SB-GL-39](https://gitlab.com/doolin/springboard/-/work_items/39) brings the 6.2.x line.

## Code-path audit

The exploit requires `@EnableMethodSecurity` (or the deprecated `@EnableGlobalMethodSecurity`) plus security annotations (`@PreAuthorize`, `@PostAuthorize`, `@Secured`, `@RolesAllowed`) on methods within generic supertypes.

| Audit | Result |
|---|---|
| `grep -rn "@EnableMethodSecurity\|@EnableGlobalMethodSecurity\|@PreAuthorize\|@PostAuthorize\|@Secured\|@RolesAllowed" src/main/java/` | **zero matches** |

This application does NOT use method-level security at all — authorization is enforced exclusively via `HttpSecurity.authorizeHttpRequests(...)` request-matcher chain in `SecurityConfig`. The annotation-resolution code path that contains the vulnerability is never invoked.

## Local Trivy delta

- Before this PR: 3 unsuppressed HIGH
- After: 2 unsuppressed HIGH (CVE-2025-22228 SB-GL-50 parked, CVE-2025-52999 SB-GL-51 next)

## Test plan

- [x] Audit grep returned zero matches.
- [x] `.trivyignore` syntax accepted by Trivy 0.70.0 locally.
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/49
- https://gitlab.com/doolin/springboard/-/work_items/39
- https://spring.io/security/cve-2025-41249