### PR TITLE
SB-GL-51 Bump jackson-bom 2.13.5 → 2.15.4 to remediate CVE-2025-52999

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <logback.version>1.2.13</logback.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <postgresql.version>42.7.11</postgresql.version>
+        <jackson-bom.version>2.15.4</jackson-bom.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

CVE-2025-52999 (jackson-core deeply-nested JSON → StackOverflowError → DoS, CVSS 8.7 HIGH) is fixed in jackson-core 2.15.0+, which introduces a configurable depth limit defaulting to 1000. The dossier flagged this as a spike: try bumping in-place vs audit-and-suppress.

**Spike result: clean bump works.** Override `<jackson-bom.version>` to 2.15.4 in `pom.xml`. Spring Boot 2.7.18 BOM + jackson 2.15.4 builds and passes the full test suite cleanly. True remediation rather than suppression — no `.trivyignore` entry needed.

## Verified

```
./mvnw -B -ntp verify
  →  128 tests, 0 failures
  →  All coverage checks have been met.
  →  BUILD SUCCESS
```

```
trivy fs --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore .
  →  1 HIGH (down from 2):
     - CVE-2025-22228 spring-security-crypto  (SB-GL-50, parked)
```

## Incidental effect

The bump also covers CVE-2024-49338 (jackson-databind unsafe deserialization, fix in 2.14.3+ / 2.15.4+) which was suppressed via code-path audit in [SB-GL-28](https://gitlab.com/doolin/springboard/-/work_items/28). That `.trivyignore` entry stays in place as defensive audit evidence — the dependency-level fix and the documented audit are belt-and-suspenders.

## Gate elevation path

After this PR + the parked SB-GL-50 work (compensating control for BCryptPasswordEncoder), the local Trivy CRITICAL,HIGH baseline will be clean. SB-GL-29 (elevate CI gate `CRITICAL` → `CRITICAL,HIGH`) then becomes a safe one-line flip.

## Test plan

- [x] Build green locally.
- [x] Trivy delta confirmed: CVE-2025-52999 no longer surfaces.
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/51
- https://nvd.nist.gov/vuln/detail/CVE-2025-52999