### PR TITLE
SB-GL-50 Compensating control for CVE-2025-22228 — 72-char password cap

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -210,3 +210,30 @@ CVE-2026-40973
 # until Spring Boot 3.x migration.
 # Removal: SB-GL-39 Spring Boot 3 migration (pulls in 6.2.x line).
 CVE-2025-41249
+
+# CVE-2025-22228 — spring-security-crypto 5.7.14 (SB-GL-50)
+# BCryptPasswordEncoder.matches(CharSequence, String) incorrectly returns
+# true for passwords longer than 72 characters when the first 72
+# characters match the legitimate password's first 72 characters —
+# authentication bypass for any account whose owner has set a >72-char
+# password.
+# Exploit precondition: a stored credential whose cleartext was >72 chars
+# at registration time AND an attacker who can guess the first 72.
+# Fix versions (5.7.16 / 5.8.18 / 6.0.16 / 6.1.14 / 6.2.10 / 6.3.8 / 6.4.4)
+# are published only via VMware Tanzu Spring Runtime (commercial feed);
+# 5.7.16 is NOT available in public Maven Central. Same situation as
+# CVE-2025-41249 (SB-GL-49) and spring-framework 5.3.45.
+# Compensating control: cleartext password input is capped at 72 chars
+# via Bean Validation at both authentication endpoints:
+#   - src/main/java/com/todoapp/dto/RegisterRequest.java: @Size(min=6, max=72)
+#   - src/main/java/com/todoapp/dto/AuthRequest.java:     @Size(max=72)
+# Requests exceeding 72 chars are rejected by Spring MVC with HTTP 400
+# before reaching BCryptPasswordEncoder.matches(). Coverage:
+# AuthControllerTest.registerRejectsPasswordOverSeventyTwoChars and
+# AuthControllerTest.loginRejectsPasswordOverSeventyTwoChars verify the
+# rejection path. Decision pathway documented in SECURITY.md
+# "Compensating control: BCrypt input-length cap (CVE-2025-22228)".
+# Removal: when (a) the spring-security-crypto fix becomes available in
+# public Maven Central OR (b) SB-GL-39 Spring Boot 3 migration pulls in
+# the 6.x line.
+CVE-2025-22228

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -157,6 +157,54 @@ Track L3 SHOULD NOT consume artifacts produced under this
 development-phase posture. Re-evaluation conditions are identical to
 AC-5 above.
 
+### Compensating control: BCrypt input-length cap (CVE-2025-22228)
+
+**Control objective:** [SP 800-53 SI-2][sp53] — Flaw remediation for
+[CVE-2025-22228][cve-22228], a HIGH-severity authentication bypass in
+`BCryptPasswordEncoder.matches(CharSequence, String)`. The matcher
+incorrectly returns `true` for passwords longer than 72 characters
+when the first 72 characters match the legitimate password's first 72
+characters.
+
+**Baseline applicability.** SI-2 applies at FIPS 199 Moderate. The
+direct remediation (`spring-security-crypto` 5.7.16 or 6.x) is
+unavailable on public Maven Central: the 5.7.x fix exists only in
+VMware Tanzu Spring Runtime (commercial / enterprise feed), and the
+6.x fix requires a Jakarta-namespace migration (SB-GL-39).
+
+**Alternative implementation.** Cleartext password input is capped at
+72 characters via Bean Validation at both authentication endpoints:
+
+- `RegisterRequest.password` — `@Size(min = 6, max = 72)` at
+  `POST /api/v1/auth/register`
+- `AuthRequest.password` — `@Size(max = 72)` at `POST /api/v1/auth/login`
+
+Spring MVC rejects requests exceeding 72 characters with HTTP 400
+before any value reaches `BCryptPasswordEncoder.matches()`. The
+attack path (submit a password whose first 72 chars match the
+stored credential and whose tail is arbitrary) is blocked at the
+boundary. Test coverage:
+`AuthControllerTest.registerRejectsPasswordOverSeventyTwoChars` and
+`AuthControllerTest.loginRejectsPasswordOverSeventyTwoChars`.
+
+**Residual risk.** Pre-existing user records whose passwords were
+set with >72-char cleartext before this control landed are NOT
+re-keyable from this measure — their stored hashes still reflect the
+truncated first 72 bytes. Operationally a forced password reset
+would close that gap; for the development-phase POC this is
+accepted-risk and re-evaluated at AO sign-off.
+
+**Re-evaluation conditions (RFC 2119 SHALL).** The compensating
+control SHALL be removed and the gate SHALL fail under any of:
+
+- `spring-security-crypto` ≥ 5.7.16 becomes available on public Maven
+  Central (then bump and revert this control).
+- Spring Boot 3.x migration (SB-GL-39) brings the 6.x line.
+
+The `.trivyignore` entry for CVE-2025-22228 cross-references this
+section as evidence of decision pathway, per [SP 800-37 Rev. 2][rmf]
+risk-acceptance framing.
+
 ### OSCAL representation
 
 These tailoring decisions are represented in the project's OSCAL
@@ -175,6 +223,7 @@ conformance with [SSDF PS.3.1][ssdf] and OMB M-24-15
 [slsa10]: https://slsa.dev/spec/v1.0/
 [sb-gl-6]: https://gitlab.com/doolin/springboard/-/work_items/6
 [sb-gl-21]: https://gitlab.com/doolin/springboard/-/work_items/21
+[cve-22228]: https://spring.io/security/cve-2025-22228
 
 ## What to expect
 

--- a/src/main/java/com/todoapp/dto/AuthRequest.java
+++ b/src/main/java/com/todoapp/dto/AuthRequest.java
@@ -1,12 +1,18 @@
 package com.todoapp.dto;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 public class AuthRequest {
     @NotBlank(message = "Username is required")
     private String username;
 
+    // Max 72 enforces BCryptPasswordEncoder.matches() input bounds. Mirrors
+    // the constraint on RegisterRequest.password; without it the login path
+    // would still accept >72-char inputs that the BCrypt matcher
+    // incorrectly accepts (CVE-2025-22228, SB-GL-50).
     @NotBlank(message = "Password is required")
+    @Size(max = 72, message = "Password cannot exceed 72 characters")
     private String password;
 
     public String getUsername() { return username; }

--- a/src/main/java/com/todoapp/dto/RegisterRequest.java
+++ b/src/main/java/com/todoapp/dto/RegisterRequest.java
@@ -13,8 +13,12 @@ public class RegisterRequest {
     @Email(message = "Email should be valid")
     private String email;
 
+    // Max 72 enforces BCryptPasswordEncoder.matches() input bounds, which is
+    // the compensating control for CVE-2025-22228 (SB-GL-50). Without this
+    // cap, BCrypt silently matches any password whose first 72 bytes match
+    // the stored hash's pre-image.
     @NotBlank(message = "Password is required")
-    @Size(min = 6, message = "Password must be at least 6 characters")
+    @Size(min = 6, max = 72, message = "Password must be between 6 and 72 characters")
     private String password;
 
     public String getUsername() { return username; }

--- a/src/test/java/com/todoapp/controller/AuthControllerTest.java
+++ b/src/test/java/com/todoapp/controller/AuthControllerTest.java
@@ -53,4 +53,28 @@ class AuthControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.username").value("bob"));
     }
+
+    // 73-character password — one past the BCryptPasswordEncoder 72-byte
+    // input limit. The DTO @Size(max = 72) cap is the compensating control
+    // for CVE-2025-22228 (SB-GL-50); both register and login must reject
+    // longer inputs before they reach BCryptPasswordEncoder.matches().
+    private static final String PASSWORD_73 = "a".repeat(73);
+
+    @Test
+    @WithMockUser
+    void registerRejectsPasswordOverSeventyTwoChars() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"bob\",\"email\":\"b@b.com\",\"password\":\"" + PASSWORD_73 + "\"}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    void loginRejectsPasswordOverSeventyTwoChars() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"alice\",\"password\":\"" + PASSWORD_73 + "\"}"))
+            .andExpect(status().isBadRequest());
+    }
 }


### PR DESCRIPTION
## Summary

CVE-2025-22228 (HIGH) — `BCryptPasswordEncoder.matches(CharSequence, String)` returns `true` for any password > 72 characters whose first 72 chars match the stored credential. Authentication bypass.

The originally-ticketed minor-version bump (5.7.14 → 5.7.16) is impossible: the fix is published only via VMware Tanzu Spring Runtime (commercial feed), not public Maven Central. Same situation as CVE-2025-41249 (SB-GL-49).

**Rescoped to a compensating control**: cap cleartext password input at 72 characters at both auth endpoints via Bean Validation. Rejected at the request boundary (HTTP 400) before `BCryptPasswordEncoder.matches()` is invoked. Attack path closed.

## Changes

| File | Change |
|---|---|
| `RegisterRequest.password` | `@Size(min = 6, max = 72)` (was `min = 6` only) |
| `AuthRequest.password` | new `@Size(max = 72)` |
| `AuthControllerTest` | two new tests — register and login reject 73-char password with 400 |
| `.trivyignore` | new CVE-2025-22228 entry with compensating-control justification |
| `SECURITY.md` | new "Compensating control: BCrypt input-length cap" subsection under Tailored Controls; mapped to [SP 800-53 SI-2](https://doi.org/10.6028/NIST.SP.800-53r5) alternative-implementation framing |

## Verified

```
./mvnw -B -ntp verify
  → 130 tests (was 128), 0 failures
  → All coverage checks have been met.
  → BUILD SUCCESS
```

```
trivy fs --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore .
  → Unsuppressed HIGH count: 0
```

## Residual risk

Pre-existing user records whose passwords were set with >72-char cleartext before this control are NOT re-keyable from this measure — their stored hashes already reflect the truncated first-72-bytes. Operationally a forced password reset would close that gap; for the development-phase POC this is accepted-risk and re-evaluated at AO sign-off.

## Unblocks SB-GL-29

With this PR merged, the local Trivy CRITICAL,HIGH baseline is clean. The next PR — [SB-GL-29](https://gitlab.com/doolin/springboard/-/work_items/29) — flips `trivy-severity: "CRITICAL"` to `"CRITICAL,HIGH"` in both forge callers and the gate elevation is safe.

## Test plan

- [x] Build green locally (130 tests).
- [x] Trivy delta confirmed: 0 unsuppressed HIGH.
- [x] Two new tests verify boundary rejection at register and login.
- [ ] CI green on GitHub after merge.

Refs:
- https://gitlab.com/doolin/springboard/-/work_items/50
- https://gitlab.com/doolin/springboard/-/work_items/39
- https://spring.io/security/cve-2025-22228